### PR TITLE
Integrate next batch as since in next sync calls

### DIFF
--- a/lib/matrix_client.ex
+++ b/lib/matrix_client.ex
@@ -64,7 +64,7 @@ defmodule MatrixClient do
     {:ok, url} = Session.get(session, :url)
     {:ok, token} = Session.get(session, :token)
     new_opts = Map.put(opts, :room_alias_name, name)
-    handle_result(Client.create_room(url, token, new_opts)) 
+    handle_result(Client.create_room(url, token, new_opts))
   end
 
   def create_anonymous_room(session, opts \\ %{}) do
@@ -118,8 +118,14 @@ defmodule MatrixClient do
     {:ok, url} = Session.get(pid, :url)
     {:ok, token} = Session.get(pid, :token)
 
+    new_opts =
+      case Session.get(pid, :next_batch) do
+        {:ok, next_batch} -> Map.put(opts, :since, next_batch)
+        _ -> opts
+      end
+
     handle_result(
-      Client.sync(url, token, opts),
+      Client.sync(url, token, new_opts),
       fn body ->
         Session.sync_rooms(pid, body)
       end

--- a/lib/matrix_client/session.ex
+++ b/lib/matrix_client/session.ex
@@ -50,6 +50,10 @@ defmodule MatrixClient.Session do
     put(bucket, :invites, new_invites)
   end
 
+  def update_next_batch(bucket, next_batch) do
+    put(bucket, :next_batch, next_batch)
+  end
+
   def delete_invite(bucket, room_id) do
     invites = get_invites(bucket)
     update_invites(bucket, Map.delete(invites, room_id))
@@ -73,6 +77,9 @@ defmodule MatrixClient.Session do
     invite_rooms = room_invite_data(data)
     new_invites = Enum.reduce(invite_rooms, get_invites(bucket), &sync_invite/2)
     update_invites(bucket, new_invites)
+
+    %{"next_batch" => next_batch} = data
+    update_next_batch(bucket, next_batch)
   end
 
   def sync_room({room_id, room_data}, rooms) do

--- a/test/matrix_client_test.exs
+++ b/test/matrix_client_test.exs
@@ -2,7 +2,7 @@ defmodule MatrixClientTest do
   use ExUnit.Case, async: false
   doctest MatrixClient
 
-  @moduletag :external  
+  @moduletag :external
 
   test "register user" do
     {:ok, pid} = MatrixClient.new_session("http://localhost:8008")
@@ -124,6 +124,5 @@ defmodule MatrixClientTest do
     MatrixClient.logout(pid)
 
     :timer.sleep(5000)
-  end  
-  
+  end
 end


### PR DESCRIPTION
Resolves #8 

Personally, I don't think this PR requires any additional tests. As I already have a test that uses two sync calls and doesn't break with this change. This feature will probably get indirectly tested with future PRs as well.